### PR TITLE
feat: initial working tile

### DIFF
--- a/my-app/src/features/baking-game/photo-puzzle/Board.jsx
+++ b/my-app/src/features/baking-game/photo-puzzle/Board.jsx
@@ -1,71 +1,78 @@
-import React, { useState } from "react";
-import Tile from "./Tile";
-import { TILE_COUNT, GRID_SIZE, BOARD_SIZE } from "./Constants";
-import { canSwap, shuffle, swap, isSolved } from "./Helpers";
+import React, {useState} from 'react';
+import Tile from './Tile';
+import {TILE_COUNT, GRID_SIZE, BOARD_SIZE} from './Constants';
+import {canSwap, shuffle, swap, isSolved} from './Helpers';
 import './Board.css';
 
+const INITIAL_TILES = [...Array(TILE_COUNT).keys()];
 
-function Board({ imgUrl }) {
-    const [tiles, setTiles] = useState([...Array(TILE_COUNT).keys()]);
-    const [isStarted, setIsStarted] = useState(false);
-    console.log('is started:', isStarted)
+function Board({imgUrl}) {
+  const [tiles, setTiles] = useState(INITIAL_TILES);
+  const [isStarted, setIsStarted] = useState(false);
+  console.log('is started:', isStarted);
 
-    const shuffleTiles = () => {
-        const shuffledTiles = shuffle(tiles)
-        setTiles(shuffleTiles);
+  const shuffleTiles = () => {
+    const shuffledTiles = shuffle(tiles);
+    setTiles(shuffledTiles);
+  };
+
+  const unFuckTiles = () => {
+    setIsStarted(false);
+    setTiles(INITIAL_TILES);
+  };
+
+  const swapTiles = tileIndex => {
+    if (canSwap(tileIndex, tiles.indexOf(tiles.length - 1))) {
+      const swappedTiles = swap(tiles, tileIndex, tiles.indexOf(tiles.length - 1));
+      setTiles(swappedTiles);
     }
+  };
 
-    const swapTiles = (tileIndex) => {
-        if (canSwap(tileIndex, tiles.indexOf(tiles.length - 1))) {
-        const swappedTiles = swap(tiles, tileIndex, tiles.indexOf(tiles.length - 1))
-        setTiles(swappedTiles)
-      }
-    }
+  const handleTileClick = index => {
+    swapTiles(index);
+  };
 
-    const handleTileClick = (index) => {
-        swapTiles(index)
-    }
+  const handleResetClick = index => {
+    unFuckTiles();
+  };
 
-    const handleShuffleClick = (index) => {
-        shuffleTiles()
-    }
+  const handleStartClick = () => {
+    shuffleTiles();
+    setIsStarted(true);
+  };
 
-    const handleStartClick = () => {
-        shuffleTiles()
-        setIsStarted(true)
-    }
+  const pieceWidth = Math.round(BOARD_SIZE / GRID_SIZE);
+  const pieceHeight = Math.round(BOARD_SIZE / GRID_SIZE);
+  const style = {
+    width: BOARD_SIZE,
+    height: BOARD_SIZE,
+  };
+  const hasWon = isSolved(tiles);
 
+  return (
+    <>
+      <ul style={style} className="board">
+        {tiles.map((tile, index) => (
+          <Tile
+            key={tile}
+            index={index}
+            imgUrl={imgUrl}
+            tile={tile}
+            tiles={tiles}
+            width={pieceWidth}
+            height={pieceHeight}
+            handleTileClick={handleTileClick}
+          />
+        ))}
+      </ul>
+      {hasWon && isStarted && <div>Puzzle solved</div>}
+      {!isStarted ? (
+        <button onClick={() => handleStartClick()}>Start game</button>
+      ) : (
+        <button onClick={() => handleResetClick()}>Reset game</button>
+      )}
+    </>
+  );
+}
 
-    const pieceWidth = Math.round(BOARD_SIZE / GRID_SIZE);
-    const pieceHeight = Math.round(BOARD_SIZE / GRID_SIZE);
-    const style = {
-      width: BOARD_SIZE,
-      height: BOARD_SIZE,
-    };
-    const hasWon = isSolved(tiles);
-
-    return (
-        <> 
-          <ul style={style} className="board">
-            {tiles.map((tile, index) => (
-              <Tile
-                key={tile}
-                index={index}
-                imgUrl={imgUrl}
-                tile={tile}
-                tiles={tiles}
-                width={pieceWidth}
-                height={pieceHeight}
-                handleTileClick={handleTileClick}
-              />
-            ))}
-          </ul>
-        {hasWon && isStarted && <div>Puzzle solved</div>}  
-        {!isStarted ?
-        (<button onClick={() => handleStartClick()}>Start game</button>) :
-        (<button onClick={() => handleShuffleClick()}>Restart game</button>)}
-        </>
-      );
-    }
-    
-    export default Board;
+export default Board;

--- a/my-app/src/features/baking-game/photo-puzzle/Helpers.jsx
+++ b/my-app/src/features/baking-game/photo-puzzle/Helpers.jsx
@@ -1,4 +1,4 @@
-import { TILE_COUNT, GRID_SIZE } from "./Constants";
+import {TILE_COUNT, GRID_SIZE} from './Constants';
 
 // Credits to https://codepen.io/unindented/pen/QNWdRQ
 export function isSolvable(tiles) {
@@ -26,10 +26,12 @@ export function getIndex(row, col) {
 }
 
 // Get the row/col pair from a linear index.
-export function getMatrixPosition(index) {
+export function getMatrixPosition(index, tile) {
   return {
-    row: Math.floor(index / GRID_SIZE),
     col: index % GRID_SIZE,
+    initialCol: tile % GRID_SIZE,
+    initialRow: Math.floor(tile / GRID_SIZE),
+    row: Math.floor(index / GRID_SIZE),
   };
 }
 
@@ -42,19 +44,15 @@ export function getVisualPosition(row, col, width, height) {
 
 export function shuffle(tiles) {
   const shuffledTiles = [
-    ...tiles
-      .filter((t) => t !== tiles.length - 1)
-      .sort(() => Math.random() - 0.5),
+    ...tiles.filter(t => t !== tiles.length - 1).sort(() => Math.random() - 0.5),
     tiles.length - 1,
   ];
-  return isSolvable(shuffledTiles) && !isSolved(shuffledTiles)
-    ? shuffledTiles
-    : shuffle(shuffledTiles);
+  return isSolvable(shuffledTiles) && !isSolved(shuffledTiles) ? shuffledTiles : shuffle(shuffledTiles);
 }
 
 export function canSwap(srcIndex, destIndex) {
-  const { row: srcRow, col: srcCol } = getMatrixPosition(srcIndex);
-  const { row: destRow, col: destCol } = getMatrixPosition(destIndex);
+  const {row: srcRow, col: srcCol} = getMatrixPosition(srcIndex);
+  const {row: destRow, col: destCol} = getMatrixPosition(destIndex);
   return Math.abs(srcRow - destRow) + Math.abs(srcCol - destCol) === 1;
 }
 
@@ -65,21 +63,21 @@ export function swap(tiles, src, dest) {
 }
 
 export function updateURLParameter(url, param, paramVal) {
-  var newAdditionalURL = "";
-  var tempArray = url.split("?");
+  var newAdditionalURL = '';
+  var tempArray = url.split('?');
   var baseURL = tempArray[0];
   var additionalURL = tempArray[1];
-  var temp = "";
+  var temp = '';
   if (additionalURL) {
-    tempArray = additionalURL.split("&");
+    tempArray = additionalURL.split('&');
     for (var i = 0; i < tempArray.length; i++) {
-      if (tempArray[i].split("=")[0] !== param) {
+      if (tempArray[i].split('=')[0] !== param) {
         newAdditionalURL += temp + tempArray[i];
-        temp = "&";
+        temp = '&';
       }
     }
   }
 
-  var rows_txt = temp + "" + param + "=" + paramVal;
-  return baseURL + "?" + newAdditionalURL + rows_txt;
+  var rows_txt = temp + '' + param + '=' + paramVal;
+  return baseURL + '?' + newAdditionalURL + rows_txt;
 }

--- a/my-app/src/features/baking-game/photo-puzzle/Puzzle.jsx
+++ b/my-app/src/features/baking-game/photo-puzzle/Puzzle.jsx
@@ -1,17 +1,14 @@
-import React from "react";
-import Board from "./Board";
+import React from 'react';
+import Board from './Board';
 import frankenbread from '../../../images/frankenbread.png';
 import './Puzzle.css';
 
 function Puzzle() {
+  return (
+    <div className="puzzle">
+      <Board imgUrl={frankenbread} />
+    </div>
+  );
+}
 
-    return (
-      <div className="puzzle">
-        <h1>PLEASE WORK DEAR GOD.</h1>
-        <Board imgUrl={frankenbread} />
-      </div>
-    );
-  }
-  
-  export default Puzzle;
-  
+export default Puzzle;

--- a/my-app/src/features/baking-game/photo-puzzle/Tile.jsx
+++ b/my-app/src/features/baking-game/photo-puzzle/Tile.jsx
@@ -1,33 +1,33 @@
-import React from "react";
-import {Motion, spring} from "react-motion";
-import { getMatrixPosition, getVisualPosition } from "./Helpers";
-import { TILE_COUNT, GRID_SIZE, BOARD_SIZE } from "./Constants";
+import React from 'react';
+import {Motion, spring} from 'react-motion';
+import {getMatrixPosition, getVisualPosition} from './Helpers';
+import {TILE_COUNT, GRID_SIZE, BOARD_SIZE} from './Constants';
 import './Tile.css';
 
-function Tile(props) {
-  const { tiles, tile, index, width, height, handleTileClick, imgUrl } = props;
-
-  const { row, col } = getMatrixPosition(index);
+const Tile = props => {
+  const {tile, index, width, height, handleTileClick, imgUrl} = props;
+  const {col, initialRow, row} = getMatrixPosition(index, tile);
   const visualPos = getVisualPosition(row, col, width, height);
+
   const tileStyle = {
-    width: `calc(100% / ${GRID_SIZE})`,
-    height: `calc(100% / ${GRID_SIZE})`,
+    height: Math.ceil(BOARD_SIZE / GRID_SIZE),
+    width: Math.ceil(BOARD_SIZE / GRID_SIZE),
     translateX: visualPos.x,
     translateY: visualPos.y,
     backgroundImage: `url(${imgUrl})`,
-    // backgroundSize: `${BOARD_SIZE}px`,
-    backgroundPosition: `${(100 / GRID_SIZE) * (tile % GRID_SIZE)}% ${(100 / GRID_SIZE) * getRowNumber(tiles, tile)}%`,
+    backgroundPosition: `${(100 / (GRID_SIZE - 1)) * (tile % GRID_SIZE)}% ${(100 * initialRow) / (GRID_SIZE - 1)}%`,
+    backgroundSize: `${GRID_SIZE * 100}%`,
   };
   const motionStyle = {
-      translateX: spring(visualPos.x),
-      translateY: spring(visualPos.y)
-  }
+    translateX: spring(visualPos.x),
+    translateY: spring(visualPos.y),
+  };
 
   return (
     <Motion style={motionStyle}>
-      {({translateX, translateY}) => (  
+      {({translateX, translateY}) => (
         <li
-        style={{
+          style={{
             ...tileStyle,
             transform: `translate3d(${translateX}px, ${translateY}px, 0)`,
             // Is last tile?
@@ -41,30 +41,6 @@ function Tile(props) {
       )}
     </Motion>
   );
-}
+};
 
 export default Tile;
-
-
-/*
-Troubleshooting from even grid size to all grid sizes from source code.
-
-Input: [0, 1, 2, 3, 4, 5, 6, 7, 8]
-Output: [0, 0, 0, 1, 1, 1, 2, 2, 2]
-*/
-
-const getRowNumber = (allTiles, thisTile) => {
-  const rowSize = Math.sqrt(allTiles.length)  
-  let rowNumber = -1;
-
-  for(let i = 0; i < allTiles.length; i++) {
-    const el = allTiles[i]
-    if(el % rowSize === 0) {
-      rowNumber++;
-    }
-
-    if(el === thisTile) {
-      return rowNumber; 
-    }
-  }
-}


### PR DESCRIPTION
1. many prettier formatting changes
2. extract INITIAL_TILES
3. bugfix using `shuffledTiles` variable name (closes https://github.com/audreywrong/personalwebsite-react/issues/8)
4. puzzle dynamic CSS fix  (closes https://github.com/audreywrong/personalwebsite-react/issues/7)
5. ability to reset puzzle into initial state
6. remove extraneous `<h1>`
7. consolidate `getRowNumber` into existing `getMatrixPosition` by having it return one more destructured value, `initialRow`